### PR TITLE
Add statusCode property to error

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function HTTPErrorFactory(code, defaultMessage) {
 
     assert(statusCode >= 400, 'Not a valid HTTP error code');
 
+    this.statusCode = statusCode;
     this.code = statusCode;
     this.message = message || defaultMessage;
   }


### PR DESCRIPTION
Restify will default to use status code 500 Internal service error if there is
not a statusCode property on the error. Adding this property will give back
the correct error codes in the response messages.

See: http://restify.com/#error-handling