### PR TITLE
Add unprocessable entity error type

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,3 +82,7 @@ module.exports.ConflictError = HTTPErrorFactory(
   'Conflict'
 );
 
+module.exports.UnprocessableEntityError = HTTPErrorFactory(
+  422,
+  'Unprocessable entity'
+);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj-service-error-types",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "common error types for various storj services",
   "main": "index.js",
   "scripts": {

--- a/test/index.unit.js
+++ b/test/index.unit.js
@@ -102,4 +102,13 @@ describe('errorTypes', function() {
       expect(ConflictError.message).to.equal('Conflict');
     });
   });
+
+  describe('UnprocessableEntity', function () {
+    it('should have default props', function () {
+      var UnprocessableEntityError = errorTypes.UnprocessableEntityError();
+      expect(UnprocessableEntityError.code).to.equal(422);
+      expect(UnprocessableEntityError.statusCode).to.equal(422);
+      expect(UnprocessableEntityError.message).to.equal('Unprocessable entity');
+    });
+  });
 });


### PR DESCRIPTION
The immediate use of this new error type would be for https://github.com/Storj/bridge/issues/488. If a rename is requested for an old file that has no index, the PATCH method would return http code 422.